### PR TITLE
Apply Vercel black and white shadcn theme with logo

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,35 +1,33 @@
 <svg width="120" height="120" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
-    <linearGradient id="logoGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#3B82F6;stop-opacity:1" />
-      <stop offset="50%" style="stop-color:#1D4ED8;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#1E40AF;stop-opacity:1" />
-    </linearGradient>
     <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
       <feDropShadow dx="0" dy="4" stdDeviation="8" flood-opacity="0.1"/>
     </filter>
   </defs>
   
   <!-- Main document background -->
-  <rect x="20" y="15" width="80" height="90" rx="8" ry="8" fill="url(#logoGradient)" filter="url(#shadow)"/>
+  <rect x="15" y="15" width="90" height="90" rx="12" ry="12" fill="currentColor" filter="url(#shadow)"/>
+  
+  <!-- Document content area -->
+  <rect x="25" y="25" width="70" height="70" rx="6" ry="6" fill="white"/>
   
   <!-- Document header lines -->
-  <rect x="30" y="28" width="35" height="3" rx="1.5" fill="white" opacity="0.9"/>
-  <rect x="30" y="36" width="35" height="3" rx="1.5" fill="white" opacity="0.9"/>
-  <rect x="30" y="52" width="20" height="3" rx="1.5" fill="white" opacity="0.7"/>
+  <rect x="32" y="35" width="40" height="2" rx="1" fill="currentColor" opacity="0.8"/>
+  <rect x="32" y="42" width="40" height="2" rx="1" fill="currentColor" opacity="0.8"/>
+  <rect x="32" y="49" width="25" height="2" rx="1" fill="currentColor" opacity="0.6"/>
   
   <!-- Dollar sign circle -->
-  <circle cx="60" cy="70" r="18" fill="white" opacity="0.95"/>
-  <text x="60" y="78" font-family="Arial, sans-serif" font-size="20" font-weight="bold" text-anchor="middle" fill="url(#logoGradient)">$</text>
+  <circle cx="60" cy="67" r="15" fill="currentColor"/>
+  <text x="60" y="73" font-family="Arial, sans-serif" font-size="18" font-weight="bold" text-anchor="middle" fill="white">$</text>
   
-  <!-- Arrow elements -->
-  <g transform="translate(75, 25)">
+  <!-- Transfer arrows -->
+  <g transform="translate(78, 32)">
     <!-- Outgoing arrow -->
-    <path d="M5 8 L15 8 L12 5 M15 8 L12 11" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.9"/>
+    <path d="M0 0 L8 0 L6 -2 M8 0 L6 2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.8"/>
   </g>
   
-  <g transform="translate(75, 40)">
+  <g transform="translate(78, 42)">
     <!-- Incoming arrow -->
-    <path d="M15 8 L5 8 L8 5 M5 8 L8 11" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.9"/>
+    <path d="M8 0 L0 0 L2 -2 M0 0 L2 2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.8"/>
   </g>
 </svg>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,55 +6,57 @@
 @layer base {
   :root {
     --background: 0 0% 100%;
-    --foreground: 240 10% 3.9%;
+    --foreground: 0 0% 3.9%;
     --card: 0 0% 100%;
-    --card-foreground: 240 10% 3.9%;
+    --card-foreground: 0 0% 3.9%;
     --popover: 0 0% 100%;
-    --popover-foreground: 240 10% 3.9%;
-    --primary: 221.2 83.2% 53.3%;
-    --primary-foreground: 210 40% 98%;
-    --secondary: 210 40% 96%;
-    --secondary-foreground: 222.2 84% 4.9%;
-    --muted: 210 40% 96%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-    --accent: 210 40% 96%;
-    --accent-foreground: 222.2 84% 4.9%;
+    --popover-foreground: 0 0% 3.9%;
+    --primary: 0 0% 9%;
+    --primary-foreground: 0 0% 98%;
+    --secondary: 0 0% 96.1%;
+    --secondary-foreground: 0 0% 9%;
+    --muted: 0 0% 96.1%;
+    --muted-foreground: 0 0% 45.1%;
+    --accent: 0 0% 96.1%;
+    --accent-foreground: 0 0% 9%;
     --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 221.2 83.2% 53.3%;
-    --radius: 0.75rem;
-    --vercel-gradient: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    --vercel-blue: 221.2 83.2% 53.3%;
-    --vercel-purple: 262.1 83.3% 57.8%;
-    --vercel-pink: 339.3 82.2% 51.8%;
-    --vercel-green: 142.1 76.2% 36.3%;
-    --vercel-yellow: 45.9 96.7% 64.5%;
-    --vercel-orange: 24.6 95% 53.1%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 0 0% 89.8%;
+    --input: 0 0% 89.8%;
+    --ring: 0 0% 3.9%;
+    --radius: 0.5rem;
+    --chart-1: 0 0% 0%;
+    --chart-2: 0 0% 18%;
+    --chart-3: 0 0% 32%;
+    --chart-4: 0 0% 46%;
+    --chart-5: 0 0% 60%;
   }
 
   .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
-    --primary: 221.2 83.2% 53.3%;
-    --primary-foreground: 222.2 84% 4.9%;
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
+    --background: 0 0% 3.9%;
+    --foreground: 0 0% 98%;
+    --card: 0 0% 3.9%;
+    --card-foreground: 0 0% 98%;
+    --popover: 0 0% 3.9%;
+    --popover-foreground: 0 0% 98%;
+    --primary: 0 0% 98%;
+    --primary-foreground: 0 0% 9%;
+    --secondary: 0 0% 14.9%;
+    --secondary-foreground: 0 0% 98%;
+    --muted: 0 0% 14.9%;
+    --muted-foreground: 0 0% 63.9%;
+    --accent: 0 0% 14.9%;
+    --accent-foreground: 0 0% 98%;
     --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 224.3 76.3% 94.1%;
-    --vercel-gradient: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    --destructive-foreground: 0 0% 98%;
+    --border: 0 0% 14.9%;
+    --input: 0 0% 14.9%;
+    --ring: 0 0% 83.1%;
+    --chart-1: 0 0% 100%;
+    --chart-2: 0 0% 82%;
+    --chart-3: 0 0% 68%;
+    --chart-4: 0 0% 54%;
+    --chart-5: 0 0% 40%;
   }
 }
 
@@ -65,10 +67,6 @@
   
   body {
     background-color: hsl(var(--background));
-    background-image: 
-      radial-gradient(circle at 25px 25px, hsl(var(--primary)/0.05) 2px, transparent 0),
-      radial-gradient(circle at 75px 75px, hsl(var(--vercel-purple)/0.05) 1px, transparent 0);
-    background-size: 100px 100px, 50px 50px;
     color: hsl(var(--foreground));
     font-feature-settings: "rlig" 1, "calt" 1;
     font-family: var(--font-rethink-sans), 'Rethink Sans', sans-serif;
@@ -105,22 +103,6 @@
   /* Smooth scrolling */
   html {
     scroll-behavior: smooth;
-  }
-
-  /* Vercel-inspired gradient backgrounds */
-  .vercel-gradient {
-    background: var(--vercel-gradient);
-  }
-
-  .vercel-gradient-text {
-    background: linear-gradient(135deg, hsl(var(--vercel-blue)), hsl(var(--vercel-purple)));
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-  }
-
-  .vercel-glow {
-    box-shadow: 0 0 20px hsl(var(--primary)/0.3);
   }
 
   /* Custom scrollbar for webkit browsers */

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -53,12 +53,12 @@ export default function HomePage() {
   ]
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50/30 via-white to-purple-50/30">
+    <div className="min-h-screen bg-background">
       {/* Header */}
-      <header className="border-b bg-white/80 backdrop-blur-sm sticky top-0 z-50">
+      <header className="border-b bg-background/80 backdrop-blur-sm sticky top-0 z-50">
         <div className="container mx-auto px-4 py-4">
           <div className="flex items-center justify-between">
-            <Logo size="md" variant="gradient" />
+            <Logo size="md" variant="default" />
             <nav className="hidden md:flex items-center space-x-6">
               <a href="#features" className="text-muted-foreground hover:text-foreground transition-colors">Features</a>
               <a href="#pricing" className="text-muted-foreground hover:text-foreground transition-colors">Pricing</a>
@@ -99,7 +99,7 @@ export default function HomePage() {
             </div>
 
             {/* File Upload Section */}
-            <Card className="max-w-3xl mx-auto shadow-xl border-0 bg-white/90 backdrop-blur-sm">
+            <Card className="max-w-3xl mx-auto shadow-xl border-0 bg-card/90 backdrop-blur-sm">
               <CardContent className="p-8">
                 <div className="mb-6">
                                   <h3 className="text-2xl font-semibold text-foreground mb-2">Upload Bank Statements</h3>
@@ -138,7 +138,7 @@ export default function HomePage() {
       </section>
 
       {/* Features Section */}
-      <section id="features" className="py-20 bg-white">
+      <section id="features" className="py-20 bg-muted/30">
         <div className="container mx-auto px-4">
           <div className="text-center mb-16">
             <h2 className="text-4xl font-bold text-foreground mb-4">
@@ -210,14 +210,12 @@ export default function HomePage() {
       </section>
 
       {/* Footer */}
-      <footer className="bg-gray-900 text-white py-12">
+      <footer className="bg-foreground text-background py-12">
         <div className="container mx-auto px-4">
           <div className="grid md:grid-cols-4 gap-8">
             <div>
               <div className="flex items-center space-x-3 mb-4">
-                <div className="bg-foreground p-2 rounded-lg">
-                  <FileText className="h-6 w-6 text-background" />
-                </div>
+                <Logo size="md" variant="inverted" showText={false} />
                 <span className="text-xl font-bold">StatementSync</span>
               </div>
               <p className="text-muted-foreground">

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -4,7 +4,7 @@ import { cn } from '@/lib/utils'
 
 interface LogoProps {
   size?: 'sm' | 'md' | 'lg' | 'xl'
-  variant?: 'default' | 'white' | 'gradient'
+  variant?: 'default' | 'white' | 'inverted'
   className?: string
   showText?: boolean
 }
@@ -19,14 +19,14 @@ const sizeMap = {
 export function Logo({ size = 'md', variant = 'default', className, showText = true }: LogoProps) {
   const logoSize = sizeMap[size]
   
-  const getGradientId = () => {
+  const getLogoColor = () => {
     switch (variant) {
       case 'white':
-        return 'logoGradientWhite'
-      case 'gradient':
-        return 'logoGradientCustom'
+        return '#ffffff'
+      case 'inverted':
+        return 'hsl(var(--background))'
       default:
-        return 'logoGradient'
+        return 'hsl(var(--foreground))'
     }
   }
 
@@ -39,21 +39,9 @@ export function Logo({ size = 'md', variant = 'default', className, showText = t
         fill="none" 
         xmlns="http://www.w3.org/2000/svg"
         className="flex-shrink-0"
+        style={{ color: getLogoColor() }}
       >
         <defs>
-          <linearGradient id="logoGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" style={{stopColor: '#3B82F6', stopOpacity: 1}} />
-            <stop offset="50%" style={{stopColor: '#1D4ED8', stopOpacity: 1}} />
-            <stop offset="100%" style={{stopColor: '#1E40AF', stopOpacity: 1}} />
-          </linearGradient>
-          <linearGradient id="logoGradientWhite" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" style={{stopColor: '#ffffff', stopOpacity: 1}} />
-            <stop offset="100%" style={{stopColor: '#f8fafc', stopOpacity: 1}} />
-          </linearGradient>
-          <linearGradient id="logoGradientCustom" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" style={{stopColor: '#667eea', stopOpacity: 1}} />
-            <stop offset="100%" style={{stopColor: '#764ba2', stopOpacity: 1}} />
-          </linearGradient>
           <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
             <feDropShadow dx="0" dy="4" stdDeviation="8" floodOpacity="0.1"/>
           </filter>
@@ -61,57 +49,97 @@ export function Logo({ size = 'md', variant = 'default', className, showText = t
         
         {/* Main document background */}
         <rect 
-          x="20" 
+          x="15" 
           y="15" 
-          width="80" 
+          width="90" 
           height="90" 
-          rx="8" 
-          ry="8" 
-          fill={`url(#${getGradientId()})`} 
+          rx="12" 
+          ry="12" 
+          fill="currentColor" 
           filter="url(#shadow)"
         />
         
+        {/* Document content area */}
+        <rect 
+          x="25" 
+          y="25" 
+          width="70" 
+          height="70" 
+          rx="6" 
+          ry="6" 
+          fill={variant === 'inverted' ? 'hsl(var(--foreground))' : 'white'}
+        />
+        
         {/* Document header lines */}
-        <rect x="30" y="28" width="35" height="3" rx="1.5" fill="white" opacity="0.9"/>
-        <rect x="30" y="36" width="35" height="3" rx="1.5" fill="white" opacity="0.9"/>
-        <rect x="30" y="52" width="20" height="3" rx="1.5" fill="white" opacity="0.7"/>
+        <rect 
+          x="32" 
+          y="35" 
+          width="40" 
+          height="2" 
+          rx="1" 
+          fill={variant === 'inverted' ? 'hsl(var(--background))' : 'currentColor'} 
+          opacity="0.8"
+        />
+        <rect 
+          x="32" 
+          y="42" 
+          width="40" 
+          height="2" 
+          rx="1" 
+          fill={variant === 'inverted' ? 'hsl(var(--background))' : 'currentColor'} 
+          opacity="0.8"
+        />
+        <rect 
+          x="32" 
+          y="49" 
+          width="25" 
+          height="2" 
+          rx="1" 
+          fill={variant === 'inverted' ? 'hsl(var(--background))' : 'currentColor'} 
+          opacity="0.6"
+        />
         
         {/* Dollar sign circle */}
-        <circle cx="60" cy="70" r="18" fill="white" opacity="0.95"/>
+        <circle 
+          cx="60" 
+          cy="67" 
+          r="15" 
+          fill={variant === 'inverted' ? 'hsl(var(--background))' : 'currentColor'}
+        />
         <text 
           x="60" 
-          y="78" 
+          y="73" 
           fontFamily="Arial, sans-serif" 
-          fontSize="20" 
+          fontSize="18" 
           fontWeight="bold" 
           textAnchor="middle" 
-          fill={`url(#${getGradientId()})`}
+          fill={variant === 'inverted' ? 'hsl(var(--foreground))' : 'white'}
         >
           $
         </text>
         
-        {/* Arrow elements */}
-        <g transform="translate(75, 25)">
+        {/* Transfer arrows */}
+        <g transform="translate(78, 32)">
           <path 
-            d="M5 8 L15 8 L12 5 M15 8 L12 11" 
-            stroke="white" 
-            strokeWidth="2.5" 
+            d="M0 0 L8 0 L6 -2 M8 0 L6 2" 
+            stroke={variant === 'inverted' ? 'hsl(var(--background))' : 'currentColor'} 
+            strokeWidth="2" 
             strokeLinecap="round" 
             strokeLinejoin="round" 
             fill="none" 
-            opacity="0.9"
+            opacity="0.8"
           />
         </g>
         
-        <g transform="translate(75, 40)">
+        <g transform="translate(78, 42)">
           <path 
-            d="M15 8 L5 8 L8 5 M5 8 L8 11" 
-            stroke="white" 
-            strokeWidth="2.5" 
+            d="M8 0 L0 0 L2 -2 M0 0 L2 2" 
+            stroke={variant === 'inverted' ? 'hsl(var(--background))' : 'currentColor'} 
+            strokeWidth="2" 
             strokeLinecap="round" 
             strokeLinejoin="round" 
             fill="none" 
-            opacity="0.9"
+            opacity="0.8"
           />
         </g>
       </svg>
@@ -125,7 +153,7 @@ export function Logo({ size = 'md', variant = 'default', className, showText = t
             size === 'lg' && 'text-2xl',
             size === 'xl' && 'text-3xl',
             variant === 'white' && 'text-white',
-            variant === 'gradient' && 'vercel-gradient-text',
+            variant === 'inverted' && 'text-background',
             variant === 'default' && 'text-foreground'
           )}
         >


### PR DESCRIPTION
Updated the application to a Vercel black and white Shadcn theme and integrated the new financial document logo.

---
<a href="https://cursor.com/background-agent?bcId=bc-0acfacd0-995d-44a7-ab0d-d2fe8c1713b9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0acfacd0-995d-44a7-ab0d-d2fe8c1713b9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>